### PR TITLE
Secure dotfiles and add Starship prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 *.pyc
 *.log
+.zshenv
+.env
+.ssh/
+*.pem
+*.key
+id_rsa
+id_rsa.pub
+.zsh_history
+.bash_history
+.history
+.DS_Store

--- a/home/.config/starship.toml
+++ b/home/.config/starship.toml
@@ -1,0 +1,9 @@
+# Starship configuration file
+# For more information, see: https://starship.rs/config/
+
+# Inserts a blank line between shell prompts
+add_newline = true
+
+# Replace the '❯' symbol in the prompt with '➜'
+# [character] # The name of the module we are configuring is 'character'
+# success_symbol = '[➜](bold green)' # The 'success_symbol' segment is being set to '➜' with the color 'bold green'

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -7,8 +7,8 @@ dsi() { docker stop $(docker ps -a | awk -v i="^$1.*" '{if($2~i){print$1}}'); }
 
 export ZSH="$HOME/.oh-my-zsh"
 
-GIT_PROMPT_END=" [\${AWS_PROFILE}]\n\A $ "
-ZSH_THEME="cloud"
+# GIT_PROMPT_END=" [\${AWS_PROFILE}]\n\A $ "
+ZSH_THEME=""
 export NVM_DIR=~/.nvm
 
   export PIPEWIRE_CONFIG_FILE="$HOME/.config/pipewire/pipewire.conf"
@@ -132,7 +132,7 @@ alias lt='eza -a --tree --level=1 --icons'
 alias orca-slicer='__GLX_VENDOR_LIBRARY_NAME=mesa __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json MESA_LOADER_DRIVER_OVERRIDE=zink GALLIUM_DRIVER=zink WEBKIT_DISABLE_DMABUF_RENDERER=1 orca-slicer'
 
 # bun completions
-[ -s "/home/melty/.bun/_bun" ] && source "/home/melty/.bun/_bun"
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
 # bun
 export BUN_INSTALL="$HOME/.bun"
@@ -147,4 +147,6 @@ eval "$(pyenv init - zsh)"
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
 
-[[ -s "/home/melty/.gvm/scripts/gvm" ]] && source "/home/melty/.gvm/scripts/gvm"
+[[ -s "$HOME/.gvm/scripts/gvm" ]] && source "$HOME/.gvm/scripts/gvm"
+
+eval "$(starship init zsh)"

--- a/home/scripts/install/packages.sh
+++ b/home/scripts/install/packages.sh
@@ -115,6 +115,7 @@ packages=(
   gwenview
   libreoffice-fresh
   gimp
+  starship
 )
 
 #TODO: exec sudo usermod -aG docker plugdev $USER


### PR DESCRIPTION
Improved security and portability of dotfiles by removing hardcoded paths and adding sensitive file exclusions to .gitignore. Integrated Starship prompt by adding it to the install script, configuring it in .zshrc, and creating a default config file.

---
*PR created automatically by Jules for task [8294920381411496622](https://jules.google.com/task/8294920381411496622) started by @krokodiili*